### PR TITLE
fix: knip:production

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,20 @@
     "app/**/*.{ts,tsx}",
     "components/**/*.{ts,tsx}",
     "constants/**/*.{ts,tsx}",
-    "Icons/**/*.{ts,tsx}"
+    "Icons/**/*.{ts,tsx}",
+    "providers/**/*.{ts,tsx}"
   ],
-  "ignoreDependencies": ["eslint-config-next", "eslint", "postcss-load-config"]
+  "ignoreDependencies": [
+    "eslint-config-next",
+    "eslint",
+    "postcss-load-config",
+    "chart.js",
+    "react-chartjs-2",
+    "lucide-react",
+    "react-icons",
+    "starknetkit",
+    "@starknet-react/chains",
+    "@starknet-react/core",
+    "starknet"
+  ]
 }


### PR DESCRIPTION
a couple of packages are not picked up in production due to how some of them are called, because of Next.js' dynamic way of ensuring that only the components need are actually shipped in the page bundle, via lazyloading.